### PR TITLE
Fix minor spelling error in until example docs

### DIFF
--- a/src/until.ts
+++ b/src/until.ts
@@ -1,7 +1,7 @@
 /**
  * Gracefully handles a given Promise factory.
  * @example
- * cosnt [error, data] = await until(() => asyncAction())
+ * const [error, data] = await until(() => asyncAction())
  */
 export const until = async <DataType = unknown, ErrorType = Error>(promise: () => Promise<DataType>): Promise<[ErrorType, DataType]> => {
   try {


### PR DESCRIPTION
## Problem

There is a minor misspelling of `const` in the example within `src/until.ts`.

## Solution

A small update to the file with corrected spelling.

## Impact

This is documentation only and should have no user facing impact.