### PR TITLE
fix: update jsdoc block to include correct example

### DIFF
--- a/src/until.ts
+++ b/src/until.ts
@@ -11,7 +11,7 @@ export type AsyncTuple<
 /**
  * Gracefully handles a given Promise factory.
  * @example
- * const [error, data] = await until(() => asyncAction())
+ * const { error, data } = await until(() => asyncAction())
  */
 export const until = async <
   ErrorType extends any = Error,


### PR DESCRIPTION
### Problem
The until function example docs is outdated, now the until function returns an object not an array.

### Solution
Corrected the example to be an object instead of an array.

### Impact
Have no impact